### PR TITLE
Moving setting of pipes from main.ts to AppModule

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { ClassSerializerInterceptor, Module, ValidationPipe } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CaslModule } from 'nest-casl';
@@ -10,6 +10,7 @@ import { ApplicationsModule } from './applications/applications.module';
 import { AuthModule } from './auth/auth.module';
 import configuration from './config/configuration';
 import { JobsModule } from './jobs/jobs.module';
+import { APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
 
 @Module({
   imports: [
@@ -37,6 +38,9 @@ import { JobsModule } from './jobs/jobs.module';
     ApplicationsModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService,
+    { provide: APP_PIPE, useValue: new ValidationPipe({ transform: true, forbidNonWhitelisted: true }) },
+    { provide: APP_INTERCEPTOR, useClass: ClassSerializerInterceptor },
+  ],
 })
 export class AppModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,6 @@
 import {
     ClassSerializerInterceptor,
     Logger,
-    ValidationPipe,
 } from '@nestjs/common';
 import { NestFactory, Reflector } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
@@ -10,20 +9,18 @@ import { AppModule } from './app.module';
 async function bootstrap() {
     const app = await NestFactory.create(AppModule);
     app.setGlobalPrefix('api');
-    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+
     app.enableCors({
         origin: 'http://localhost:5173',
         credentials: true,
     }); // TODO Update this for production
+    
     app.useGlobalInterceptors(
         new ClassSerializerInterceptor(app.get(Reflector), {
             excludeExtraneousValues: true,
         }),
     );
-    //validation pipes globally
-    app.useGlobalPipes(
-        new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }),
-    );
+
     const logger = new Logger('Main');
     // Swagger OpenAPI
     const options = new DocumentBuilder()


### PR DESCRIPTION
E-Mail validation was currently failing in e2e tests. 
I couldn't figure out why, Tests through making API calls manually were fine, but e2e tests validation was getting skipped. 
The issue is explained below:

The below is `main.ts`. We are setting to use global pipes and in that we are setting validation pipe.
```
async function bootstrap() {
    const app = await NestFactory.create(AppModule);
    app.setGlobalPrefix('api');
    app.useGlobalPipes(new ValidationPipe({ transform: true }));
```
In test creation also we need to mention the same. I have created a pull request for the same to include pipes and all interceptors during test creation.
```
    beforeAll(async () => {
        moduleFixture = await Test.createTestingModule({
            imports: [AppModule],
        }).compile();

        app = moduleFixture.createNestApplication();
        app.useGlobalPipes(new ValidationPipe({ transform: true}) # this was missing.
        await app.init();

        await request(app.getHttpServer())
            .post('/auth/register')
            .send(testUser)
            .expect(HttpStatus.CREATED);
    });
```

To make sure testing config(pipes, interceptors) and prod app (pipes, interceptors) are always configured properly. I made this fix. 